### PR TITLE
Establecer encoding en la respuesta en el cliente al hacer login

### DIFF
--- a/todus/client.py
+++ b/todus/client.py
@@ -135,7 +135,10 @@ class ToDusClient:
             url = "https://auth.todus.cu/v2/auth/token"
             with self.session.post(url, data=data, headers=headers) as resp:
                 resp.raise_for_status()
-                token = "".join([c for c in resp.text if c in string.printable])
+                # Default Encoding for HTML4 ISO-8859-1 (Latin-1)
+                token = "".join(
+                    c for c in resp.content.decode("latin-1") if c in string.printable
+                )
                 return token
 
         return self._run_task(task, self.timeout)


### PR DESCRIPTION
`resp.text` el `resp.encoding` es `None` por lo que en algunas respuestas se  aplica encoding incorrectamente devolviendo el token vacio.

Se recomienda usar el decoding to ISO-8859-1 (Latin-1)