### PR TITLE
ToDusClient.upload_file permite usar tipo de url especifico (no solo voice)

### DIFF
--- a/todus/client.py
+++ b/todus/client.py
@@ -85,7 +85,7 @@ class ToDusClient:
                             "<iq i='"
                             + sid
                             + "-3' t='get'><query xmlns='todus:purl' type='"
-                            + str(file_type)
+                            + str(int(file_type))
                             + "' persistent='false' size='"
                             + str(filesize)
                             + "' room=''></query></iq>"

--- a/todus/client.py
+++ b/todus/client.py
@@ -304,7 +304,7 @@ class ToDusClient2(ToDusClient):
     def upload_file(self, data: bytes, size: int = None, t: int = 1) -> str:  # noqa
         """Upload data and return the download URL."""
         assert self.token, "Token needed"
-        return super().upload_file(self.token, data, size)
+        return super().upload_file(self.token, data, size, t)
 
     def download_file(self, url: str, path: str) -> int:  # noqa
         """Download file URL.

--- a/todus/client.py
+++ b/todus/client.py
@@ -7,6 +7,7 @@ import socket
 import ssl
 import string
 import time
+from enum import IntEnum
 from base64 import b64decode, b64encode
 from contextlib import contextmanager
 from http.client import IncompleteRead
@@ -19,6 +20,16 @@ from .errors import AuthenticationError, EndOfStreamError, TokenExpiredError
 from .util import generate_token
 
 _BUFFERSIZE = 1024 * 1024
+
+class FileType(IntEnum):
+    FILE = 0
+    VOICE = 1
+    AUDIO = 2
+    VIDEO = 3
+    PICTURE = 4
+    PROFILE = 5
+    PROFILE_THUMBNAIL = 6
+    
 
 
 class ToDusClient:
@@ -211,16 +222,8 @@ class ToDusClient:
             token = "".join([c for c in resp.text if c in string.printable])
             return token
 
-    def upload_file(self, token: str, data: bytes, size: int = None, t: int = 1) -> str:
-        """Upload data and return the download URL.
-        t: url type used for uploading (default 1)
-          0 - file
-          1 - voice
-          2 - audio
-          3 - video
-          4 - picture
-          5 - profile
-          6 - profile thumbnail"""
+    def upload_file(self, token: str, data: bytes, size: int = None, file_type: FileType = FileType.VOICE) -> str:
+        """Upload data and return the download URL."""
         assert t in range(7), f"'{t}' is'nt valid type"
         up_url, down_url = self._reserve_url(token, size or len(data), t)
         headers = {
@@ -310,17 +313,8 @@ class ToDusClient2(ToDusClient):
         assert self.password, "Can't login without password"
         self.token = super().login(self.phone_number, self.password)
 
-    def upload_file(self, data: bytes, size: int = None, t: int = 1) -> str:  # noqa
-        """Upload data and return the download URL.
-        t: url type used for uploading (default 1)
-          0 - file
-          1 - voice
-          2 - audio
-          3 - video
-          4 - picture
-          5 - profile
-          6 - profile thumbnail"""
-        assert t in range(7), f"'{t}' is'nt valid type"
+    def upload_file(self, data: bytes, size: int = None, file_type: FileType = FileType.VOICE) -> str:  # noqa
+        """Upload data and return the download URL."""
         assert self.token, "Token needed"
         return super().upload_file(self.token, data, size, t)
 

--- a/todus/client.py
+++ b/todus/client.py
@@ -23,6 +23,7 @@ _BUFFERSIZE = 1024 * 1024
 
 
 class FileType(IntEnum):
+    """ToDus attachment type."""
     FILE = 0
     VOICE = 1
     AUDIO = 2

--- a/todus/client.py
+++ b/todus/client.py
@@ -212,7 +212,16 @@ class ToDusClient:
             return token
 
     def upload_file(self, token: str, data: bytes, size: int = None, t: int = 1) -> str:
-        """Upload data and return the download URL."""
+        """Upload data and return the download URL.
+        t: url type used for uploading (default 1)
+          0 - file
+          1 - voice
+          2 - audio
+          3 - video
+          4 - picture
+          5 - profile
+          6 - profile thumbnail"""
+        assert t in range(7), f"'{t}' is'nt valid type"
         up_url, down_url = self._reserve_url(token, size or len(data), t)
         headers = {
             "User-Agent": self.upload_ua,
@@ -302,7 +311,16 @@ class ToDusClient2(ToDusClient):
         self.token = super().login(self.phone_number, self.password)
 
     def upload_file(self, data: bytes, size: int = None, t: int = 1) -> str:  # noqa
-        """Upload data and return the download URL."""
+        """Upload data and return the download URL.
+        t: url type used for uploading (default 1)
+          0 - file
+          1 - voice
+          2 - audio
+          3 - video
+          4 - picture
+          5 - profile
+          6 - profile thumbnail"""
+        assert t in range(7), f"'{t}' is'nt valid type"
         assert self.token, "Token needed"
         return super().upload_file(self.token, data, size, t)
 

--- a/todus/client.py
+++ b/todus/client.py
@@ -318,9 +318,9 @@ class ToDusClient2(ToDusClient):
         assert self.password, "Can't login without password"
         self.token = super().login(self.phone_number, self.password)
 
-    def upload_file(
+    def upload_file(  # noqa
         self, data: bytes, size: int = None, file_type: FileType = FileType.VOICE
-    ) -> str:  # noqa
+    ) -> str:
         """Upload data and return the download URL."""
         assert self.token, "Token needed"
         return super().upload_file(self.token, data, size, file_type)

--- a/todus/client.py
+++ b/todus/client.py
@@ -57,7 +57,7 @@ class ToDusClient:
             with _socket:
                 yield _socket
 
-    def _reserve_url(self, token: str, filesize: int) -> tuple:
+    def _reserve_url(self, token: str, filesize: int, t: int) -> tuple:
         phone, authstr = _parse_token(token)
         sid = generate_token(5)
 
@@ -73,7 +73,9 @@ class ToDusClient:
                         (
                             "<iq i='"
                             + sid
-                            + "-3' t='get'><query xmlns='todus:purl' type='1' persistent='false' size='"
+                            + "-3' t='get'><query xmlns='todus:purl' type='"
+                            + str(t)
+                            + "' persistent='false' size='"
                             + str(filesize)
                             + "' room=''></query></iq>"
                         ).encode()
@@ -209,9 +211,9 @@ class ToDusClient:
             token = "".join([c for c in resp.text if c in string.printable])
             return token
 
-    def upload_file(self, token: str, data: bytes, size: int = None) -> str:
+    def upload_file(self, token: str, data: bytes, size: int = None, t: int = 1) -> str:
         """Upload data and return the download URL."""
-        up_url, down_url = self._reserve_url(token, size or len(data))
+        up_url, down_url = self._reserve_url(token, size or len(data), t)
         headers = {
             "User-Agent": self.upload_ua,
             "Authorization": f"Bearer {token}",

--- a/todus/client.py
+++ b/todus/client.py
@@ -68,7 +68,7 @@ class ToDusClient:
             with _socket:
                 yield _socket
 
-    def _reserve_url(self, token: str, filesize: int, t: int) -> tuple:
+    def _reserve_url(self, token: str, filesize: int, file_type: FileType) -> tuple:
         phone, authstr = _parse_token(token)
         sid = generate_token(5)
 
@@ -85,7 +85,7 @@ class ToDusClient:
                             "<iq i='"
                             + sid
                             + "-3' t='get'><query xmlns='todus:purl' type='"
-                            + str(t)
+                            + str(file_type)
                             + "' persistent='false' size='"
                             + str(filesize)
                             + "' room=''></query></iq>"
@@ -224,8 +224,7 @@ class ToDusClient:
 
     def upload_file(self, token: str, data: bytes, size: int = None, file_type: FileType = FileType.VOICE) -> str:
         """Upload data and return the download URL."""
-        assert t in range(7), f"'{t}' is'nt valid type"
-        up_url, down_url = self._reserve_url(token, size or len(data), t)
+        up_url, down_url = self._reserve_url(token, size or len(data), file_type)
         headers = {
             "User-Agent": self.upload_ua,
             "Authorization": f"Bearer {token}",
@@ -316,7 +315,7 @@ class ToDusClient2(ToDusClient):
     def upload_file(self, data: bytes, size: int = None, file_type: FileType = FileType.VOICE) -> str:  # noqa
         """Upload data and return the download URL."""
         assert self.token, "Token needed"
-        return super().upload_file(self.token, data, size, t)
+        return super().upload_file(self.token, data, size, file_type)
 
     def download_file(self, url: str, path: str) -> int:  # noqa
         """Download file URL.

--- a/todus/client.py
+++ b/todus/client.py
@@ -301,7 +301,7 @@ class ToDusClient2(ToDusClient):
         assert self.password, "Can't login without password"
         self.token = super().login(self.phone_number, self.password)
 
-    def upload_file(self, data: bytes, size: int = None) -> str:  # noqa
+    def upload_file(self, data: bytes, size: int = None, t: int = 1) -> str:  # noqa
         """Upload data and return the download URL."""
         assert self.token, "Token needed"
         return super().upload_file(self.token, data, size)

--- a/todus/client.py
+++ b/todus/client.py
@@ -24,6 +24,7 @@ _BUFFERSIZE = 1024 * 1024
 
 class FileType(IntEnum):
     """ToDus attachment type."""
+
     FILE = 0
     VOICE = 1
     AUDIO = 2

--- a/todus/client.py
+++ b/todus/client.py
@@ -7,9 +7,9 @@ import socket
 import ssl
 import string
 import time
-from enum import IntEnum
 from base64 import b64decode, b64encode
 from contextlib import contextmanager
+from enum import IntEnum
 from http.client import IncompleteRead
 from threading import Lock
 from typing import Callable, Generator

--- a/todus/client.py
+++ b/todus/client.py
@@ -21,6 +21,7 @@ from .util import generate_token
 
 _BUFFERSIZE = 1024 * 1024
 
+
 class FileType(IntEnum):
     FILE = 0
     VOICE = 1
@@ -29,7 +30,6 @@ class FileType(IntEnum):
     PICTURE = 4
     PROFILE = 5
     PROFILE_THUMBNAIL = 6
-    
 
 
 class ToDusClient:
@@ -222,7 +222,13 @@ class ToDusClient:
             token = "".join([c for c in resp.text if c in string.printable])
             return token
 
-    def upload_file(self, token: str, data: bytes, size: int = None, file_type: FileType = FileType.VOICE) -> str:
+    def upload_file(
+        self,
+        token: str,
+        data: bytes,
+        size: int = None,
+        file_type: FileType = FileType.VOICE,
+    ) -> str:
         """Upload data and return the download URL."""
         up_url, down_url = self._reserve_url(token, size or len(data), file_type)
         headers = {
@@ -312,7 +318,9 @@ class ToDusClient2(ToDusClient):
         assert self.password, "Can't login without password"
         self.token = super().login(self.phone_number, self.password)
 
-    def upload_file(self, data: bytes, size: int = None, file_type: FileType = FileType.VOICE) -> str:  # noqa
+    def upload_file(
+        self, data: bytes, size: int = None, file_type: FileType = FileType.VOICE
+    ) -> str:  # noqa
         """Upload data and return the download URL."""
         assert self.token, "Token needed"
         return super().upload_file(self.token, data, size, file_type)


### PR DESCRIPTION
Permite usar
`ToDusClient.upload_file(data, t=n)`
donde `n: int` representa un tipo de url el cual usar para subir archivos
Valores:
- 0: File
- 1: Voice (default)
- 2: Audio
- 3: Video
- 4: Picture
- 5: Profile
- 6: Profile Thumbnail